### PR TITLE
docs: fixed typos in plugins' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,11 +471,11 @@ import { plugins, applyPlugins, parse } from 'parse-commit-message';
 
 console.log(plugins); // =>  [mentions, increment]
 console.log(plugins[0]); // => [Function mentions]
-console.log(plugins[0]); // => [Function increment]
+console.log(plugins[1]); // => [Function increment]
 
 const cmts = parse([
   'fix: foo @bar @qux haha',
-  'feat(cli): awesome @tunnckoCore feature\n\nSuper duper baz!'
+  'feat(cli): awesome @tunnckoCore feature\n\nSuper duper baz!',
   'fix: ooh\n\nBREAKING CHANGE: some awful api change'
 ]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -107,11 +107,11 @@ export function applyPlugins(plugins, commits) {
  *
  * console.log(plugins); // =>  [mentions, increment]
  * console.log(plugins[0]); // => [Function mentions]
- * console.log(plugins[0]); // => [Function increment]
+ * console.log(plugins[1]); // => [Function increment]
  *
  * const cmts = parse([
  *   'fix: foo @bar @qux haha',
- *   'feat(cli): awesome @tunnckoCore feature\n\nSuper duper baz!'
+ *   'feat(cli): awesome @tunnckoCore feature\n\nSuper duper baz!',
  *   'fix: ooh\n\nBREAKING CHANGE: some awful api change'
  * ]);
  *


### PR DESCRIPTION
Just couldn't pass by these typos :) 

-----
[View rendered README.md](https://github.com/kutyepov/parse-commit-message/blob/docs/fix-typo-in-plugins-example/README.md)